### PR TITLE
Remove unnecessary uses of `#[repr(packed)]`.

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -3,7 +3,7 @@ use Error;
 
 /// A 3D vector.
 #[derive(PartialEq, Copy, Clone, Debug)]
-#[repr(C, packed)]
+#[repr(C)]
 pub struct Vector {
 	/// The x.
 	pub x: f32,
@@ -17,17 +17,17 @@ pub struct Vector {
 
 /// A 3D vector representing position.
 #[derive(PartialEq, Copy, Clone, Debug)]
-#[repr(C, packed)]
+#[repr(C)]
 pub struct Position(pub Vector);
 
 /// A 3D vector representing direction.
 #[derive(PartialEq, Copy, Clone, Debug)]
-#[repr(C, packed)]
+#[repr(C)]
 pub struct Direction(pub Vector);
 
 /// A 3D vector representing velocity.
 #[derive(PartialEq, Copy, Clone, Debug)]
-#[repr(C, packed)]
+#[repr(C)]
 pub struct Velocity(pub Vector);
 
 /// Two 3D vectors representing orientation.


### PR DESCRIPTION
These structs are laid out the same way with or without `packed`, since
they're just repeats of a single element type. That is, they're always
going to be three contiguous `f32`s.

The removal is good because there's some correctness issues with it, so
there may be breaking changes to it in future and removing it now will
avoid them all together. See
https://github.com/rust-lang/rust/issues/27060.
